### PR TITLE
Add opty

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -111,7 +111,7 @@ dependencies:
   - pydy
 
   # optimizing dynamic systems using direct collocation
-  # - opty=1.0.0 # NOTE not installing due to it only having packages for python up to 3.6. repackage?
+  - opty
 
   # common linear algebra library
   # highest version is 2.17, but it conflicts with xeus-cling


### PR DESCRIPTION
https://github.com/conda-forge/opty-feedstock/issues/13 is no longer an issue due to https://github.com/conda-forge/opty-feedstock/pull/15, so adding it back to our image.