### PR TITLE
Install SageMath through conda

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -170,6 +170,9 @@ dependencies:
   # c++ kernel
   - xeus-cling
 
+  # sagemath (kernel included)
+  - sage
+
   # allow installation of pip packages
   - pip
   - pip:

--- a/postBuild
+++ b/postBuild
@@ -1,25 +1,5 @@
 #!/bin/bash -e
 
-# install sagemath 9.1
-# doing it here because the apt version is 8.1, uses python2, and conflicts the heck out with conda's python3
-# and installing it via conda just never finishes solving
-# instead, we download from source and unpack into /srv/conda (because it's one of the few writable directories we have)
-# the tar creates a SageMath folder so we can just unpack it into /srv/conda
-echo "Installing SageMath, this will take a while..."
-if [ `curl -s https://mirrors.mit.edu/sage/linux/64bit/sage-9.1-Ubuntu_18.04-x86_64.tar.bz2 | tee >(tar xjC /srv/conda) | md5sum | head -c32` != "97f09d3f7cd473f1d07e1b3768fc2c27" ]; then
-    echo "SageMath md5sum verification failed!"
-    exit 1
-fi
-echo "SageMath unpacked, performing setup..."
-# patch sagemath paths
-/srv/conda/SageMath/relocate-once.py >/dev/null
-# add sagemath to path by just plopping it in /srv/conda/bin/sage
-ln -s /srv/conda/SageMath/sage /srv/conda/bin
-# add sagemath kernel (along with setting SAGE_ROOT correctly)
-sed -i 's|.$|,"env": {"SAGE_ROOT": "/srv/conda/SageMath"}}|' /srv/conda/SageMath/local/share/jupyter/kernels/sagemath/kernel.json
-jupyter kernelspec install --user /srv/conda/SageMath/local/share/jupyter/kernels/sagemath/
-echo "SageMath installed"
-
 # install some lab extensions
 
 # enable nbgitpuller URLs


### PR DESCRIPTION
This moves installing SageMath from postBuild to conda. We weren't able to do this because conda took forever to solve, but mamba works well. This shrunk our image size from 21.6GB uncompressed to 15.3GB uncompressed (6.3GB savings), or 6.4GB compressed to 4.9GB compressed (1.5GB savings).

Running a couple of cursory commands in a SageMath notebook seems to indicate it's working, and I can run test cases using `sage -t lib/python3.7/site-packages/sage/*` and it seems to function. `sage -t -a` does not work for some reason, but I think that's a minor issue and all the important sage functionality is there. I'll wait for some confirmation before merging this though (you can spawn a notebook and test using binder).