### PR TITLE
2.3.3 to pin ipycytoscape=1.0.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   # some jupyter widgets
   - ipyvolume
   - nglview
-  - ipycytoscape=1.0.4
+  - ipycytoscape=1.0.4 # pinned until we switch to jupyterlab3
 
   # scikits for machine learning and image processing
   - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
   # some jupyter widgets
   - ipyvolume
   - nglview
-  - ipycytoscape
+  - ipycytoscape=1.0.4
 
   # scikits for machine learning and image processing
   - scikit-learn


### PR DESCRIPTION
This PR simply pins ipycytoscape=1.0.4 so that it works with our jupyterlab=2.2. 

I've git tagged the current staging branch and built this branch on binder.libretexts.org. After this PR is merged, the master branch will be 1 commit ahead of staging and the 2.3.3 tag will still reflect this staging branch. We should decide whether we want to git tag the master branch after we make PR and rebuild the image with this latter commit (takes a long time and I'm not a fan) or just leave the tag on the staging branch, using the image built with this branch, and have master just be a stable record of *almost* the image that we are using (the git tag will exactly reflect the image we are using).

We can also git tag the master branch and not rebuild the image, but it makes more sense to have the git tags correspond to the commit that we used to build the actual image that we pull from dockerhub rather than one that is 1 commit ahead due to a PR merge. Whichever way we choose, it will have no effect on the name of the image that we pull from dockerhub in our helm charts and ckeditor binder plugin.