### PR TITLE
Jupyter-archive extension

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -191,3 +191,6 @@ dependencies:
 
     # package requested by Richard
     - diagrams
+
+    # jupyter archive extension
+    - jupyter-archive


### PR DESCRIPTION
Adds the [jupyter-archive](https://github.com/jupyterlab-contrib/jupyter-archive) extension, which allows for zipping up files and stuff.

I've tested it and it seems to work as intended.

https://github.com/LibreTexts/metalc/issues/119